### PR TITLE
Port to SDL 2.0

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -77,20 +77,20 @@ AM_PATH_SDL($SDL_VERSION,
 ###################################################
 # Checks for C libraries.
 # SDL_mixer
-AC_CHECK_LIB([SDL_mixer], [Mix_OpenAudio],
-             SDL_LIBS="-lSDL_mixer $SDL_LIBS",
+AC_CHECK_LIB([SDL2_mixer], [Mix_OpenAudio],
+             SDL_LIBS="-lSDL2_mixer $SDL_LIBS",
              [AC_MSG_ERROR([*** SDL_mixer-devel library not found!])],
              $SDL_CFLAGS $SDL_LIBS
 )
 # SDL_image
-AC_CHECK_LIB([SDL_image], [IMG_Load],
-             SDL_LIBS="-lSDL_image $SDL_LIBS",
+AC_CHECK_LIB([SDL2_image], [IMG_Load],
+             SDL_LIBS="-lSDL2_image $SDL_LIBS",
              [AC_MSG_ERROR([*** SDL_image-devel library not found!])],
              $SDL_CFLAGS $SDL_LIBS
 )
 # SDL_ttf
-AC_CHECK_LIB([SDL_ttf], [TTF_OpenFont],
-             SDL_LIBS="-lSDL_ttf $SDL_LIBS",
+AC_CHECK_LIB([SDL2_ttf], [TTF_OpenFont],
+             SDL_LIBS="-lSDL2_ttf $SDL_LIBS",
              [AC_MSG_ERROR([*** SDL_ttf-devel library not found!])],
              $SDL_CFLAGS $SDL_LIBS
 )

--- a/sdl.m4
+++ b/sdl.m4
@@ -22,19 +22,19 @@ AC_ARG_ENABLE(sdltest, [  --disable-sdltest       Do not try to compile and run 
   if test x$sdl_exec_prefix != x ; then
      sdl_args="$sdl_args --exec-prefix=$sdl_exec_prefix"
      if test x${SDL_CONFIG+set} != xset ; then
-        SDL_CONFIG=$sdl_exec_prefix/bin/sdl-config
+        SDL_CONFIG=$sdl_exec_prefix/bin/sdl2-config
      fi
   fi
   if test x$sdl_prefix != x ; then
      sdl_args="$sdl_args --prefix=$sdl_prefix"
      if test x${SDL_CONFIG+set} != xset ; then
-        SDL_CONFIG=$sdl_prefix/bin/sdl-config
+        SDL_CONFIG=$sdl_prefix/bin/sdl2-config
      fi
   fi
 
   AC_REQUIRE([AC_CANONICAL_TARGET])
   PATH="$prefix/bin:$prefix/usr/bin:$PATH"
-  AC_PATH_PROG(SDL_CONFIG, sdl-config, no, [$PATH])
+  AC_PATH_PROG(SDL_CONFIG, sdl2-config, no, [$PATH])
   min_sdl_version=ifelse([$1], ,0.11.0,$1)
   AC_MSG_CHECKING(for SDL - version >= $min_sdl_version)
   no_sdl=""
@@ -98,6 +98,7 @@ int main (int argc, char *argv[])
      printf("%s, bad version string\n", "$min_sdl_version");
      exit(1);
    }
+  free(tmp_version);
 
    if (($sdl_major_version > major) ||
       (($sdl_major_version == major) && ($sdl_minor_version > minor)) ||

--- a/src/effect/Color.h
+++ b/src/effect/Color.h
@@ -13,7 +13,7 @@ class Color : public SDL_Color {
             this->r = red;
             this->g = green;
             this->b = blue;
-            this->unused = alpha;
+            this->a = alpha;
         }
 };
 

--- a/src/effect/EffectDisintegrate.cpp
+++ b/src/effect/EffectDisintegrate.cpp
@@ -63,7 +63,7 @@ EffectDisintegrate::blit(SDL_Surface *screen, SDL_Surface *surface,
         for (int px = 0; px < surface->w; ++px) {
             if (Random::aByte(py * surface->w + px) < m_disint) {
                 SDL_Color pixel = PixelTool::getColor(surface, px, py);
-                if (pixel.unused == 255) {
+                if (pixel.a == 255) {
                     PixelTool::putColor(screen, x + px, y + py, pixel);
                 }
             }

--- a/src/effect/EffectMirror.cpp
+++ b/src/effect/EffectMirror.cpp
@@ -36,7 +36,7 @@ EffectMirror::blit(SDL_Surface *screen, SDL_Surface *surface, int x, int y)
                 PixelTool::putColor(screen, x + px, y + py, sample);
             }
             else {
-                if (pixel.unused == 255) {
+                if (pixel.a == 255) {
                     PixelTool::putColor(screen, x + px, y + py, pixel);
                 }
             }

--- a/src/effect/EffectReverse.cpp
+++ b/src/effect/EffectReverse.cpp
@@ -25,7 +25,7 @@ EffectReverse::blit(SDL_Surface *screen, SDL_Surface *surface, int x, int y)
     for (int py = 0; py < surface->h; ++py) {
         for (int px = 0; px < surface->w; ++px) {
             SDL_Color pixel = PixelTool::getColor(surface, px, py);
-            if (pixel.unused == 255) {
+            if (pixel.a == 255) {
                 PixelTool::putColor(screen,
                         x + surface->w - 1 - px, y + py, pixel);
             }

--- a/src/effect/Font.cpp
+++ b/src/effect/Font.cpp
@@ -134,11 +134,11 @@ Font::renderText(const std::string &text, const SDL_Color &color) const
     }
 
     //NOTE: at index 0 is bg color
-    if (SDL_SetColorKey(raw_surface, SDL_SRCCOLORKEY, 0) < 0) {
+    if (SDL_SetColorKey(raw_surface, SDL_TRUE, 0) < 0) {
         throw SDLException(ExInfo("SetColorKey"));
     }
 
-    SDL_Surface *surface = SDL_DisplayFormat(raw_surface);
+    SDL_Surface *surface = SDL_ConvertSurfaceFormat(raw_surface, SDL_PIXELFORMAT_RGBA8888, 0);
     if (!surface) {
         throw SDLException(ExInfo("DisplayFormat"));
     }

--- a/src/effect/Font.h
+++ b/src/effect/Font.h
@@ -16,6 +16,7 @@ class Path;
 class Font : public NoCopy {
     private:
         TTF_Font *m_ttfont;
+        TTF_Font *m_outline;
         SDL_Color m_bg;
     private:
         static std::string biditize(const std::string &text);
@@ -28,7 +29,7 @@ class Font : public NoCopy {
         int getHeight() { return TTF_FontHeight(m_ttfont); }
         int calcTextWidth(const std::string &text);
         SDL_Surface *renderText(const std::string &text,
-                const SDL_Color &color) const;
+                const SDL_Color &color, TTF_Font* font=NULL) const;
         SDL_Surface *renderTextOutlined(const std::string &text,
                 const SDL_Color &color, int outlineWidth=1) const;
 };

--- a/src/effect/LayeredPicture.cpp
+++ b/src/effect/LayeredPicture.cpp
@@ -98,7 +98,7 @@ LayeredPicture::drawOn(SDL_Surface *screen)
 
             if (sample == m_activeColor) {
                 SDL_Color lower = PixelTool::getColor(m_lowerLayer, px, py);
-                if (lower.unused == 255) {
+                if (lower.a == 255) {
                     PixelTool::putColor(screen,
                             m_loc.getX() + px, world_y, lower);
                 }

--- a/src/effect/Outline.cpp
+++ b/src/effect/Outline.cpp
@@ -27,7 +27,8 @@ Outline::Outline(const SDL_Color &color, int width)
 void
 Outline::drawOnColorKey(SDL_Surface *surface)
 {
-    Uint32 bgKey = surface->format->colorkey;
+    Uint32 bgKey;
+    SDL_GetColorKey(surface, &bgKey);
     drawOn(surface, bgKey);
 }
 //-----------------------------------------------------------------

--- a/src/effect/PixelIterator.cpp
+++ b/src/effect/PixelIterator.cpp
@@ -49,7 +49,9 @@ PixelIterator::setPos(const V2 &pos)
 bool
 PixelIterator::isTransparent() const
 {
-    return getPixel() == m_surface->format->colorkey;
+	Uint32 key;
+	SDL_GetColorKey(m_surface, &key);
+    return getPixel() == key;
 }
 //-----------------------------------------------------------------
 SDL_Color
@@ -57,7 +59,7 @@ PixelIterator::getColor() const
 {
     SDL_Color color;
     SDL_GetRGBA(getPixel(), m_surface->format,
-            &color.r, &color.g, &color.b, &color.unused);
+            &color.r, &color.g, &color.b, &color.a);
     return color;
 }
 //-----------------------------------------------------------------
@@ -71,7 +73,7 @@ PixelIterator::getPixel() const
 PixelIterator::putColor(const SDL_Color &color)
 {
     Uint32 pixel = SDL_MapRGBA(m_surface->format,
-            color.r, color.g, color.b, color.unused);
+            color.r, color.g, color.b, color.a);
     putPixel(pixel);
 }
 //-----------------------------------------------------------------

--- a/src/effect/PixelTool.cpp
+++ b/src/effect/PixelTool.cpp
@@ -41,7 +41,7 @@ PixelTool::getColor(SDL_Surface *surface, int x, int y)
 {
     SDL_Color color;
     SDL_GetRGBA(getPixel(surface, x, y), surface->format,
-            &color.r, &color.g, &color.b, &color.unused);
+            &color.r, &color.g, &color.b, &color.a);
     return color;
 }
 //-----------------------------------------------------------------
@@ -55,7 +55,7 @@ PixelTool::putColor(SDL_Surface *surface, int x, int y,
         const SDL_Color &color)
 {
     Uint32 pixel = SDL_MapRGBA(surface->format,
-            color.r, color.g, color.b, color.unused);
+            color.r, color.g, color.b, color.a);
     putPixel(surface, x, y, pixel);
 }
 //-----------------------------------------------------------------

--- a/src/effect/SurfaceTool.cpp
+++ b/src/effect/SurfaceTool.cpp
@@ -46,7 +46,7 @@ SurfaceTool::createEmpty(SDL_Surface *surface, int width, int height)
     SDL_Surface *
 SurfaceTool::createTransparent(int w, int h, const SDL_Color &transparent)
 {
-    SDL_Surface *surface = SDL_CreateRGBSurface(SDL_SWSURFACE|SDL_SRCCOLORKEY,
+    SDL_Surface *surface = SDL_CreateRGBSurface(SDL_SWSURFACE,//|SDL_SRCCOLORKEY,
             w, h, 32,
             0, 0, 0, 0);
     if (NULL == surface) {
@@ -55,7 +55,8 @@ SurfaceTool::createTransparent(int w, int h, const SDL_Color &transparent)
 
     Uint32 transparentKey = SDL_MapRGB(surface->format,
             transparent.r, transparent.g, transparent.b);
-    SDL_SetColorKey(surface, SDL_SRCCOLORKEY|SDL_RLEACCEL, transparentKey);
+    SDL_SetSurfaceRLE(surface, SDL_TRUE);
+    SDL_SetColorKey(surface, SDL_TRUE, transparentKey);
 
     SurfaceTool::alphaFill(surface, NULL, transparent);
     return surface;
@@ -96,9 +97,11 @@ SurfaceTool::alphaFill(SDL_Surface *surface, SDL_Rect *dstrect,
         h = dstrect->h;
     }
     SDL_Surface *canvas = createEmpty(surface, w, h);
-    Uint32 pixel = SDL_MapRGB(canvas->format, color.r, color.g, color.b);
+    Uint32 pixel = SDL_MapRGBA(canvas->format, color.r, color.g, color.b, color.a);
     SDL_FillRect(canvas, NULL, pixel);
-    SDL_SetAlpha(canvas, SDL_SRCALPHA|SDL_RLEACCEL, color.unused);
+    SDL_SetSurfaceRLE(canvas, SDL_TRUE);
+    //FIXME: how to do this in SDL2?
+    //SDL_SetAlpha(canvas, SDL_SRCALPHA, color.a);
 
     SDL_BlitSurface(canvas, NULL, surface, dstrect);
     SDL_FreeSurface(canvas);

--- a/src/gengine/InputAgent.cpp
+++ b/src/gengine/InputAgent.cpp
@@ -34,9 +34,9 @@ InputAgent::own_init()
 {
     m_keyBinder = new KeyBinder();
     m_handler = NULL;
-    m_keys = SDL_GetKeyState(NULL);
+    m_keys = SDL_GetKeyboardState(NULL);
 
-    SDL_EnableUNICODE(1);
+    //SDL_EnableUNICODE(1);
 }
 //-----------------------------------------------------------------
     void

--- a/src/gengine/InputAgent.cpp
+++ b/src/gengine/InputAgent.cpp
@@ -115,10 +115,16 @@ InputAgent::getMouseState(Uint8 *out_buttons)
     int x;
     int y;
     Uint8 pressed = SDL_GetMouseState(&x, &y);
+    // Scale and translate x and y coordinates.
+    SDL_MouseButtonEvent m;
+    m.x = x;
+    m.y = y;
+    m.button = SDL_BUTTON_LEFT;
+    MouseStroke s(m);
     if (out_buttons) {
         *out_buttons = pressed;
     }
-    return V2(x, y);
+    return s.getLoc();
 }
 
 

--- a/src/gengine/InputAgent.h
+++ b/src/gengine/InputAgent.h
@@ -16,7 +16,7 @@ class InputHandler;
 class InputAgent : public BaseAgent {
     AGENT(InputAgent, Name::INPUT_NAME);
     private:
-        Uint8 *m_keys;
+        const Uint8 *m_keys;
         KeyBinder *m_keyBinder;
         InputHandler *m_handler;
     private:

--- a/src/gengine/InputHandler.cpp
+++ b/src/gengine/InputHandler.cpp
@@ -26,7 +26,7 @@ InputHandler::mouseState(const V2 &loc, Uint8 buttons)
 }
 //-----------------------------------------------------------------
 bool
-InputHandler::isPressed(SDLKey key) const
+InputHandler::isPressed(SDL_Keycode key) const
 {
     return m_pressed && m_pressed[key];
 }

--- a/src/gengine/InputHandler.cpp
+++ b/src/gengine/InputHandler.cpp
@@ -26,7 +26,7 @@ InputHandler::mouseState(const V2 &loc, Uint8 buttons)
 }
 //-----------------------------------------------------------------
 bool
-InputHandler::isPressed(SDL_Keycode key) const
+InputHandler::isPressed(SDL_Scancode key) const
 {
     return m_pressed && m_pressed[key];
 }

--- a/src/gengine/InputHandler.h
+++ b/src/gengine/InputHandler.h
@@ -19,19 +19,19 @@ class MouseStroke;
  */
 class InputHandler : public InputProvider, public NoCopy {
     private:
-        Uint8 *m_pressed;
+        const Uint8 *m_pressed;
         Uint8 m_buttons;
         V2 m_mouseLoc;
     public:
         InputHandler();
-        void takePressed(Uint8 *pressed) { m_pressed = pressed; }
+        void takePressed(const Uint8 *pressed) { m_pressed = pressed; }
         void mouseState(const V2 &loc, Uint8 buttons);
 
         virtual void keyEvent(const KeyStroke &/*stroke*/) {}
         virtual void keyUp(const KeyStroke &/*stroke*/) {}
         virtual void mouseEvent(const MouseStroke &/*buttons*/) {}
 
-        virtual bool isPressed(SDLKey key) const;
+        virtual bool isPressed(SDL_Keycode key) const;
         virtual bool isLeftPressed() const;
         virtual bool isMiddlePressed() const;
         virtual bool isRightPressed() const;

--- a/src/gengine/InputHandler.h
+++ b/src/gengine/InputHandler.h
@@ -31,7 +31,7 @@ class InputHandler : public InputProvider, public NoCopy {
         virtual void keyUp(const KeyStroke &/*stroke*/) {}
         virtual void mouseEvent(const MouseStroke &/*buttons*/) {}
 
-        virtual bool isPressed(SDL_Keycode key) const;
+        virtual bool isPressed(SDL_Scancode key) const;
         virtual bool isLeftPressed() const;
         virtual bool isMiddlePressed() const;
         virtual bool isRightPressed() const;

--- a/src/gengine/InputProvider.h
+++ b/src/gengine/InputProvider.h
@@ -12,7 +12,7 @@
 class InputProvider {
     public:
         virtual ~InputProvider() {}
-        virtual bool isPressed(SDLKey key) const = 0;
+        virtual bool isPressed(SDL_Keycode key) const = 0;
         virtual bool isLeftPressed() const = 0;
         virtual bool isRightPressed() const = 0;
         virtual bool isMiddlePressed() const = 0;

--- a/src/gengine/InputProvider.h
+++ b/src/gengine/InputProvider.h
@@ -12,7 +12,7 @@
 class InputProvider {
     public:
         virtual ~InputProvider() {}
-        virtual bool isPressed(SDL_Keycode key) const = 0;
+        virtual bool isPressed(SDL_Scancode key) const = 0;
         virtual bool isLeftPressed() const = 0;
         virtual bool isRightPressed() const = 0;
         virtual bool isMiddlePressed() const = 0;

--- a/src/gengine/KeyBinder.cpp
+++ b/src/gengine/KeyBinder.cpp
@@ -65,7 +65,7 @@ KeyBinder::removeStroke(const KeyStroke &stroke)
  * find keystroke and send message.
  */
 void
-KeyBinder::keyDown(const SDL_keysym &keysym) const
+KeyBinder::keyDown(const SDL_Keysym &keysym) const
 {
     KeyStroke stroke(keysym);
     t_strokes::const_iterator it = m_strokes.find(stroke);

--- a/src/gengine/KeyBinder.h
+++ b/src/gengine/KeyBinder.h
@@ -21,7 +21,7 @@ class KeyBinder : public NoCopy {
         void addStroke(const KeyStroke &stroke, BaseMsg *msg);
         void removeStroke(const KeyStroke &stroke);
 
-        void keyDown(const SDL_keysym &keysym) const;
+        void keyDown(const SDL_Keysym &keysym) const;
 };
 
 #endif

--- a/src/gengine/KeyStroke.cpp
+++ b/src/gengine/KeyStroke.cpp
@@ -14,11 +14,11 @@
 /**
  * Create new keystroke from event.
  */
-KeyStroke::KeyStroke(const SDL_keysym &keysym)
+KeyStroke::KeyStroke(const SDL_Keysym &keysym)
 {
     m_sym = keysym.sym;
     m_mod = modStrip(keysym.mod);
-    m_unicode = keysym.unicode;
+    m_unicode = keysym.sym;
 }
 //-----------------------------------------------------------------
 /**
@@ -29,7 +29,7 @@ KeyStroke::KeyStroke(const SDL_keysym &keysym)
  * @param sym SDLKey
  * @param mod SDLMod ored
  */
-KeyStroke::KeyStroke(SDLKey sym, int mod)
+KeyStroke::KeyStroke(SDL_Keycode sym, int mod)
 {
     m_sym = sym;
     m_mod = modStrip(mod);

--- a/src/gengine/KeyStroke.h
+++ b/src/gengine/KeyStroke.h
@@ -10,16 +10,16 @@
 class KeyStroke {
     private:
         static const int STROKE_IGNORE = ~(KMOD_CTRL|KMOD_ALT);
-        SDLKey m_sym;
+        SDL_Keycode m_sym;
         int m_mod;
         Uint16 m_unicode;
     private:
         static int modStrip(int mod);
     public:
-        KeyStroke(const SDL_keysym &keysym);
-        KeyStroke(SDLKey sym, int mod);
+        KeyStroke(const SDL_Keysym &keysym);
+        KeyStroke(SDL_Keycode sym, int mod);
 
-        SDLKey getKey() const { return m_sym; }
+        SDL_Keycode getKey() const { return m_sym; }
         Uint16 getUnicode() const { return m_unicode; }
         bool less(const KeyStroke &other) const;
         bool equals(const KeyStroke &other) const;

--- a/src/gengine/MouseStroke.cpp
+++ b/src/gengine/MouseStroke.cpp
@@ -15,7 +15,7 @@
  * Create new stroke from MouseButtonEvent.
  */
 MouseStroke::MouseStroke(const SDL_MouseButtonEvent &event)
-    : m_loc(event.x, event.y)
+    : m_loc(event.x, event.y), m_doScale(true)
 {
     m_button = event.button;
 }
@@ -45,6 +45,11 @@ void MouseStroke::getScale(float& x, float& y)
     x=scaleX;
     y=scaleY;
 }
+// Only needed for options menu in fullscreen
+void MouseStroke::disableScaling()
+{
+    m_doScale = false;
+}
 void MouseStroke::setLetterbox(V2 letterbox)
 {
     MouseStroke::letterbox = letterbox;
@@ -56,13 +61,11 @@ void MouseStroke::setResolution(V2 logical, V2 render)
 }
 V2 MouseStroke::getLoc() const
 {
-    if (letterbox.getX() && (m_loc.getX() < letterbox.getX() || m_loc.getX() > renderRes.getX()-letterbox.getX())) {
-        // the mouse cursor is in the blank area left or right
-        return V2(-1, -1);
+    if (m_doScale) {
+        return V2((m_loc.getX() - letterbox.getX()) * scaleX, (m_loc.getY() - letterbox.getY()) * scaleY);
     }
-    if (letterbox.getY() && (m_loc.getY() < letterbox.getY() || m_loc.getY() > renderRes.getY()-letterbox.getY())) {
-        // mouse cursor is in above/below letterbox
-        return V2(-1, -1);
+    else {
+        // in options menu, probably
+        return m_loc;
     }
-    return V2((m_loc.getX() - letterbox.getX()) * scaleX, (m_loc.getY() - letterbox.getY()) * scaleY);
 }

--- a/src/gengine/MouseStroke.cpp
+++ b/src/gengine/MouseStroke.cpp
@@ -29,3 +29,40 @@ MouseStroke::toString() const
     return StringTool::toString(m_button);
 }
 
+float MouseStroke::scaleX = 1.0;
+float MouseStroke::scaleY = 1.0;
+V2 MouseStroke::letterbox = V2(0, 0);
+V2 MouseStroke::logicalRes = V2(0, 0);
+V2 MouseStroke::renderRes = V2(0, 0);
+void MouseStroke::setScale(float x, float y)
+{
+    assert(x > 0 && y > 0);
+    scaleX=x;
+    scaleY=y;
+}
+void MouseStroke::getScale(float& x, float& y)
+{
+    x=scaleX;
+    y=scaleY;
+}
+void MouseStroke::setLetterbox(V2 letterbox)
+{
+    MouseStroke::letterbox = letterbox;
+}
+void MouseStroke::setResolution(V2 logical, V2 render)
+{
+    MouseStroke::logicalRes = logical;
+    MouseStroke::renderRes = render;
+}
+V2 MouseStroke::getLoc() const
+{
+    if (letterbox.getX() && (m_loc.getX() < letterbox.getX() || m_loc.getX() > renderRes.getX()-letterbox.getX())) {
+        // the mouse cursor is in the blank area left or right
+        return V2(-1, -1);
+    }
+    if (letterbox.getY() && (m_loc.getY() < letterbox.getY() || m_loc.getY() > renderRes.getY()-letterbox.getY())) {
+        // mouse cursor is in above/below letterbox
+        return V2(-1, -1);
+    }
+    return V2((m_loc.getX() - letterbox.getX()) * scaleX, (m_loc.getY() - letterbox.getY()) * scaleY);
+}

--- a/src/gengine/MouseStroke.h
+++ b/src/gengine/MouseStroke.h
@@ -13,6 +13,7 @@ class MouseStroke {
     private:
         Uint8 m_button;
         V2 m_loc;
+        bool m_doScale;
         static float scaleX, scaleY;
         static V2 letterbox, logicalRes, renderRes;
     public:
@@ -23,6 +24,7 @@ class MouseStroke {
         bool isRight() const { return m_button == SDL_BUTTON_RIGHT; }
         static void setScale(float x, float y);
         static void getScale(float& x, float& y);
+        void disableScaling();
         static void setLetterbox(V2 letterbox);
         static void setResolution(V2 logical, V2 render);
         V2 getLoc() const;

--- a/src/gengine/MouseStroke.h
+++ b/src/gengine/MouseStroke.h
@@ -13,13 +13,19 @@ class MouseStroke {
     private:
         Uint8 m_button;
         V2 m_loc;
+        static float scaleX, scaleY;
+        static V2 letterbox, logicalRes, renderRes;
     public:
         MouseStroke(const SDL_MouseButtonEvent &event);
 
         bool isLeft() const { return m_button == SDL_BUTTON_LEFT; }
         bool isMiddle() const { return m_button == SDL_BUTTON_MIDDLE; }
         bool isRight() const { return m_button == SDL_BUTTON_RIGHT; }
-        V2 getLoc() const { return m_loc; }
+        static void setScale(float x, float y);
+        static void getScale(float& x, float& y);
+        static void setLetterbox(V2 letterbox);
+        static void setResolution(V2 logical, V2 render);
+        V2 getLoc() const;
         std::string toString() const;
 };
 

--- a/src/gengine/ResImagePack.cpp
+++ b/src/gengine/ResImagePack.cpp
@@ -47,7 +47,7 @@ ResImagePack::loadImage(const Path &file)
                 .addInfo("file", file.getNative()));
     }
 
-    SDL_Surface *surface = SDL_DisplayFormatAlpha(raw_image);
+    SDL_Surface *surface = SDL_ConvertSurfaceFormat(raw_image, SDL_PIXELFORMAT_RGBA8888, 0);
     if (NULL == surface) {
         throw SDLException(ExInfo("DisplayFormat")
                 .addInfo("file", file.getNative()));

--- a/src/gengine/ResImagePack.cpp
+++ b/src/gengine/ResImagePack.cpp
@@ -48,6 +48,15 @@ ResImagePack::loadImage(const Path &file)
                 .addInfo("file", file.getNative()));
     }
 
+    // ConvertSurface might change the format so we need to convert the color
+    // key to RGB, convert the surface, and then convert back from RGB to color key.
+    Uint32 key;
+    Uint8 r, g, b;
+    int key_enabled = SDL_GetColorKey(raw_image, &key) >= 0;
+    if (key_enabled) {
+        SDL_GetRGB(key, raw_image->format, &r, &g, &b);
+    }
+
     /* SDL_ConvertSurfaceFormat causes pink corners on the 'solved' and 'next puzzle' map markers
      * It turns out that SDL_ConvertSurfaceFormat doesn't copy palette information (i.e the color key)
      * Commenting the next few lines out out fixes those pink artifacts, but the death animation
@@ -61,6 +70,11 @@ ResImagePack::loadImage(const Path &file)
                 .addInfo("file", file.getNative()));
     }
     SDL_FreeSurface(raw_image);
+
+    if (key_enabled) {
+        key = SDL_MapRGB(surface->format, r, g, b);
+        SDL_SetColorKey(surface, SDL_TRUE, key);
+    }
 
     return surface;
 }

--- a/src/gengine/ResImagePack.cpp
+++ b/src/gengine/ResImagePack.cpp
@@ -47,14 +47,18 @@ ResImagePack::loadImage(const Path &file)
                 .addInfo("file", file.getNative()));
     }
 
+    /* This code causes pink corners on the 'solved' and 'next puzzle' map markers
+     * It turns out that SDL_ConvertSurfaceFormat doesn't copy palette information (i.e the color key)
+     * Commenting this part out fixes those pink artifacts.
     SDL_Surface *surface = SDL_ConvertSurfaceFormat(raw_image, SDL_PIXELFORMAT_RGBA8888, 0);
     if (NULL == surface) {
         throw SDLException(ExInfo("DisplayFormat")
                 .addInfo("file", file.getNative()));
     }
     SDL_FreeSurface(raw_image);
+    */
 
-    return surface;
+    return raw_image;
 }
 //-----------------------------------------------------------------
 /**

--- a/src/gengine/ResImagePack.cpp
+++ b/src/gengine/ResImagePack.cpp
@@ -13,6 +13,7 @@
 #include "SDLException.h"
 #include "OptionAgent.h"
 #include "Log.h"
+#include "VideoAgent.h"
 
 #include "SDL_image.h"
 
@@ -47,18 +48,21 @@ ResImagePack::loadImage(const Path &file)
                 .addInfo("file", file.getNative()));
     }
 
-    /* This code causes pink corners on the 'solved' and 'next puzzle' map markers
+    /* SDL_ConvertSurfaceFormat causes pink corners on the 'solved' and 'next puzzle' map markers
      * It turns out that SDL_ConvertSurfaceFormat doesn't copy palette information (i.e the color key)
-     * Commenting this part out fixes those pink artifacts.
-    SDL_Surface *surface = SDL_ConvertSurfaceFormat(raw_image, SDL_PIXELFORMAT_RGBA8888, 0);
+     * Commenting the next few lines out out fixes those pink artifacts, but the death animation
+     * has a green background for some reason. Using SDL_ConvertSurface instead of
+     * ConvertSurfaceFormat fixes both bugs.
+     */
+    SDL_PixelFormat* format = VideoAgent::agent()->getPixelFormat();
+    SDL_Surface *surface = SDL_ConvertSurface(raw_image, format, 0);
     if (NULL == surface) {
         throw SDLException(ExInfo("DisplayFormat")
                 .addInfo("file", file.getNative()));
     }
     SDL_FreeSurface(raw_image);
-    */
 
-    return raw_image;
+    return surface;
 }
 //-----------------------------------------------------------------
 /**

--- a/src/gengine/SDLSoundAgent.cpp
+++ b/src/gengine/SDLSoundAgent.cpp
@@ -145,9 +145,11 @@ SDLSoundAgent::playMusic(const Path &file,
         }
     }
     else {
-        m_looper = new SDLMusicLooper(file);
+        m_music = Mix_LoadMUS(file.getNative().c_str());
+        Mix_PlayMusic(m_music, -1);
+        /*m_looper = new SDLMusicLooper(file);
         m_looper->setVolume(m_musicVolume);
-        m_looper->start();
+        m_looper->start();*/
     }
 }
 //-----------------------------------------------------------------

--- a/src/gengine/SysVideo.cpp
+++ b/src/gengine/SysVideo.cpp
@@ -13,9 +13,9 @@
 #include "SDL.h"
 #if !defined(HAVE_X11) && !defined(WIN32)
     void
-SysVideo::setCaption(const std::string &title)
+SysVideo::setCaption(SDL_Window *window, const std::string &title)
 {
-    SDL_WM_SetCaption(title.c_str(), NULL);
+    SDL_SetWindowTitle(window, title.c_str());
 }
 #else
 #include "SDL_syswm.h"

--- a/src/gengine/SysVideo.cpp
+++ b/src/gengine/SysVideo.cpp
@@ -55,14 +55,14 @@ sysSetCaption(SDL_SysWMinfo *info, const std::string &title)
     bool result = false;
 #ifdef X_HAVE_UTF8_STRING
     if (info->subsystem == SDL_SYSWM_X11) {
-        info->info.x11.lock_func();
+        XLockDisplay(info->info.x11.display);
 
         XTextProperty titleprop;
         char *text_list = const_cast<char*>(title.c_str());
         int error = Xutf8TextListToTextProperty(info->info.x11.display,
                 &text_list, 1, XUTF8StringStyle, &titleprop);
         if (!error) {
-            XSetWMName(info->info.x11.display, info->info.x11.wmwindow,
+            XSetWMName(info->info.x11.display, info->info.x11.window,
                     &titleprop);
             XFree(titleprop.value);
             result = true;
@@ -73,7 +73,7 @@ sysSetCaption(SDL_SysWMinfo *info, const std::string &title)
                     .addInfo("title", title));
         }
 
-        info->info.x11.unlock_func();
+        XUnlockDisplay(info->info.x11.display);
     }
 #endif
     return result;

--- a/src/gengine/SysVideo.cpp
+++ b/src/gengine/SysVideo.cpp
@@ -27,17 +27,17 @@ static bool sysSetCaption(SDL_SysWMinfo *info, const std::string &title);
  * @param title UTF-8 string
  */
     void
-SysVideo::setCaption(const std::string &title)
+SysVideo::setCaption(SDL_Window *window, const std::string &title)
 {
     bool done = false;
     SDL_SysWMinfo info;
     SDL_VERSION(&info.version);
-    if (SDL_GetWMInfo(&info) > 0) {
+    if (SDL_GetWindowWMInfo(window, &info) > 0) {
         done = sysSetCaption(&info, title);
     }
 
     if (!done) {
-        SDL_WM_SetCaption(title.c_str(), NULL);
+        SDL_SetWindowTitle(window, title.c_str());
     }
 }
 //-----------------------------------------------------------------

--- a/src/gengine/SysVideo.h
+++ b/src/gengine/SysVideo.h
@@ -2,13 +2,14 @@
 #define HEADER_SYSVIDEO_H
 
 #include <string>
+#include <SDL.h>
 
 /**
  * System dependend video functions.
  */
 class SysVideo {
     public:
-        static void setCaption(const std::string &title);
+        static void setCaption(SDL_Window *window, const std::string &title);
 };
 
 #endif

--- a/src/gengine/VideoAgent.cpp
+++ b/src/gengine/VideoAgent.cpp
@@ -55,7 +55,8 @@ VideoAgent::own_init()
 VideoAgent::own_update()
 {
     drawOn(m_screen);
-    SDL_RenderPresent(m_renderer);
+    //SDL_RenderPresent(m_renderer);
+    SDL_UpdateWindowSurface(m_window);
 }
 //-----------------------------------------------------------------
 /**
@@ -144,6 +145,7 @@ VideoAgent::changeVideoMode(int screen_width, int screen_height)
 
     if (newScreen) {
         m_window = newScreen;
+        m_screen = SDL_GetWindowSurface(m_window);
         //NOTE: must be two times to change MouseState
         SDL_WarpMouseInWindow(m_window, screen_width / 2, screen_height / 2);
         SDL_WarpMouseInWindow(m_window, screen_width / 2, screen_height / 2);

--- a/src/gengine/VideoAgent.cpp
+++ b/src/gengine/VideoAgent.cpp
@@ -329,3 +329,7 @@ VideoAgent::receiveString(const StringMsg *msg)
     }
 }
 
+SDL_PixelFormat* VideoAgent::getPixelFormat() {
+    return m_screen->format;
+    //return SDL_GetWindowSurface(m_window)->format;
+}

--- a/src/gengine/VideoAgent.cpp
+++ b/src/gengine/VideoAgent.cpp
@@ -42,10 +42,12 @@ VideoAgent::own_init()
     }
     atexit(SDL_Quit);
 
-    setIcon(Path::dataReadPath("images/icon.png"));
-
     registerWatcher("fullscreen");
     initVideoMode();
+
+    // The icon must be set after window creation otherwise setting the icon
+    // has no effect and a generic icon is shown instead.
+    setIcon(Path::dataReadPath("images/icon.png"));
 }
 //-----------------------------------------------------------------
 /**

--- a/src/gengine/VideoAgent.h
+++ b/src/gengine/VideoAgent.h
@@ -21,6 +21,7 @@ class VideoAgent : public BaseAgent, public MultiDrawer {
         SDL_Surface *m_screen;
         SDL_Window *m_window;
         SDL_Renderer *m_renderer;
+        SDL_Texture *m_texture;
         bool m_fullscreen;
 
     private:

--- a/src/gengine/VideoAgent.h
+++ b/src/gengine/VideoAgent.h
@@ -19,6 +19,8 @@ class VideoAgent : public BaseAgent, public MultiDrawer {
     AGENT(VideoAgent, Name::VIDEO_NAME);
     private:
         SDL_Surface *m_screen;
+        SDL_Window *m_window;
+        SDL_Renderer *m_renderer;
         bool m_fullscreen;
 
     private:

--- a/src/gengine/VideoAgent.h
+++ b/src/gengine/VideoAgent.h
@@ -6,6 +6,7 @@ class Path;
 #include "BaseAgent.h"
 #include "MultiDrawer.h"
 #include "Name.h"
+#include "V2.h"
 
 #include "SDL.h"
 
@@ -29,6 +30,8 @@ class VideoAgent : public BaseAgent, public MultiDrawer {
         void changeVideoMode(int screen_width, int screen_height);
         int getVideoFlags();
         void toggleFullScreen();
+        /* Calculate fullscreen letterboxing */
+        V2 calculateLetterbox(int w, int h, int renderW, int renderH);
     protected:
         virtual void own_init();
         virtual void own_update();

--- a/src/gengine/VideoAgent.h
+++ b/src/gengine/VideoAgent.h
@@ -39,6 +39,7 @@ class VideoAgent : public BaseAgent, public MultiDrawer {
     public:
         virtual void receiveSimple(const SimpleMsg *msg);
         virtual void receiveString(const StringMsg *msg);
+        SDL_PixelFormat *getPixelFormat();
 
         void initVideoMode();
 };

--- a/src/level/Controls.cpp
+++ b/src/level/Controls.cpp
@@ -243,7 +243,7 @@ Controls::switchActive()
 void
 Controls::controlEvent(const KeyStroke &stroke)
 {
-    SDLKey key = stroke.getKey();
+    SDL_Keycode key = stroke.getKey();
 
     if (m_strokeSymbol == ControlSym::SYM_NONE) {
         if (m_active != m_units.end()) {

--- a/src/level/KeyControl.cpp
+++ b/src/level/KeyControl.cpp
@@ -15,9 +15,9 @@
  */
 KeyControl::KeyControl()
 {
-    m_up = SDLK_UP;
-    m_down = SDLK_DOWN;
-    m_left = SDLK_LEFT;
-    m_right = SDLK_RIGHT;
+    m_up = SDL_SCANCODE_UP;
+    m_down = SDL_SCANCODE_DOWN;
+    m_left = SDL_SCANCODE_LEFT;
+    m_right = SDL_SCANCODE_RIGHT;
 }
 

--- a/src/level/KeyControl.h
+++ b/src/level/KeyControl.h
@@ -8,21 +8,21 @@
  */
 class KeyControl {
     private:
-        SDLKey m_up;
-        SDLKey m_down;
-        SDLKey m_left;
-        SDLKey m_right;
+        SDL_Keycode m_up;
+        SDL_Keycode m_down;
+        SDL_Keycode m_left;
+        SDL_Keycode m_right;
     public:
         KeyControl();
-        void setUp(SDLKey key) { m_up = key; }
-        void setDown(SDLKey key) { m_down = key; }
-        void setLeft(SDLKey key) { m_left = key; }
-        void setRight(SDLKey key) { m_right = key; }
+        void setUp(SDL_Keycode key) { m_up = key; }
+        void setDown(SDL_Keycode key) { m_down = key; }
+        void setLeft(SDL_Keycode key) { m_left = key; }
+        void setRight(SDL_Keycode key) { m_right = key; }
 
-        SDLKey getUp() const { return m_up; }
-        SDLKey getDown() const { return m_down; }
-        SDLKey getLeft() const { return m_left; }
-        SDLKey getRight() const { return m_right; }
+        SDL_Keycode getUp() const { return m_up; }
+        SDL_Keycode getDown() const { return m_down; }
+        SDL_Keycode getLeft() const { return m_left; }
+        SDL_Keycode getRight() const { return m_right; }
 };
 
 #endif

--- a/src/level/KeyControl.h
+++ b/src/level/KeyControl.h
@@ -8,21 +8,21 @@
  */
 class KeyControl {
     private:
-        SDL_Keycode m_up;
-        SDL_Keycode m_down;
-        SDL_Keycode m_left;
-        SDL_Keycode m_right;
+        SDL_Scancode m_up;
+        SDL_Scancode m_down;
+        SDL_Scancode m_left;
+        SDL_Scancode m_right;
     public:
         KeyControl();
-        void setUp(SDL_Keycode key) { m_up = key; }
-        void setDown(SDL_Keycode key) { m_down = key; }
-        void setLeft(SDL_Keycode key) { m_left = key; }
-        void setRight(SDL_Keycode key) { m_right = key; }
+        void setUp(SDL_Scancode key) { m_up = key; }
+        void setDown(SDL_Scancode key) { m_down = key; }
+        void setLeft(SDL_Scancode key) { m_left = key; }
+        void setRight(SDL_Scancode key) { m_right = key; }
 
-        SDL_Keycode getUp() const { return m_up; }
-        SDL_Keycode getDown() const { return m_down; }
-        SDL_Keycode getLeft() const { return m_left; }
-        SDL_Keycode getRight() const { return m_right; }
+        SDL_Scancode getUp() const { return m_up; }
+        SDL_Scancode getDown() const { return m_down; }
+        SDL_Scancode getLeft() const { return m_left; }
+        SDL_Scancode getRight() const { return m_right; }
 };
 
 #endif

--- a/src/level/ModelFactory.cpp
+++ b/src/level/ModelFactory.cpp
@@ -103,18 +103,18 @@ ModelFactory::createUnit(const std::string &kind)
     Unit *result = NULL;
     if ("fish_small" == kind) {
         KeyControl smallfish;
-        smallfish.setUp(SDLK_i);
-        smallfish.setDown(SDLK_k);
-        smallfish.setLeft(SDLK_j);
-        smallfish.setRight(SDLK_l);
+        smallfish.setUp(SDL_SCANCODE_I);
+        smallfish.setDown(SDL_SCANCODE_K);
+        smallfish.setLeft(SDL_SCANCODE_J);
+        smallfish.setRight(SDL_SCANCODE_L);
         result = new Unit(smallfish, ControlSym('u', 'd', 'l', 'r'), true);
     }
     else if ("fish_big" == kind) {
         KeyControl bigfish;
-        bigfish.setUp(SDLK_w);
-        bigfish.setDown(SDLK_s);
-        bigfish.setLeft(SDLK_a);
-        bigfish.setRight(SDLK_d);
+        bigfish.setUp(SDL_SCANCODE_W);
+        bigfish.setDown(SDL_SCANCODE_S);
+        bigfish.setLeft(SDL_SCANCODE_A);
+        bigfish.setRight(SDL_SCANCODE_D);
         result = new Unit(bigfish, ControlSym('U', 'D', 'L', 'R'));
     }
     else if (StringTool::startsWith(kind, "fish_extra") ||

--- a/src/level/ModelFactory.cpp
+++ b/src/level/ModelFactory.cpp
@@ -121,10 +121,10 @@ ModelFactory::createUnit(const std::string &kind)
         StringTool::startsWith(kind, "fish_EXTRA"))
     {
         KeyControl extrafish;
-        extrafish.setUp(SDLK_LAST);
-        extrafish.setDown(SDLK_LAST);
-        extrafish.setLeft(SDLK_LAST);
-        extrafish.setRight(SDLK_LAST);
+        extrafish.setUp(SDL_NUM_SCANCODES);
+        extrafish.setDown(SDL_NUM_SCANCODES);
+        extrafish.setLeft(SDL_NUM_SCANCODES);
+        extrafish.setRight(SDL_NUM_SCANCODES);
         result = new Unit(extrafish, parseExtraControlSym(kind));
     }
     return result;

--- a/src/level/ShapeBuilder.cpp
+++ b/src/level/ShapeBuilder.cpp
@@ -28,7 +28,7 @@ ShapeBuilder::prepareColor(SDL_Color *color, const Shape *shape,
     color->r = 0;
     color->g = 0;
     color->b = 0;
-    color->unused = 255;
+    color->a = 255;
 
     switch (weight) {
         case Cube::LIGHT:

--- a/src/level/Unit.cpp
+++ b/src/level/Unit.cpp
@@ -97,7 +97,7 @@ Unit::activate()
  * @return symbol or SYM_NONE for unknown key
  */
 char
-Unit::mySymbol(SDLKey key) const
+Unit::mySymbol(SDL_Keycode key) const
 {
     return mySymbolBorrowed(key, m_buttons);
 }
@@ -107,7 +107,7 @@ Unit::mySymbol(SDLKey key) const
  * @return symbol or SYM_NONE for unknown key
  */
 char
-Unit::mySymbolBorrowed(SDLKey key, const KeyControl &buttons) const
+Unit::mySymbolBorrowed(SDL_Keycode key, const KeyControl &buttons) const
 {
     if (key == buttons.getLeft()) {
         return m_symbols.getLeft();

--- a/src/level/Unit.h
+++ b/src/level/Unit.h
@@ -39,8 +39,8 @@ class Unit {
                 const KeyControl &buttons);
         void activate();
 
-        char mySymbol(SDLKey key) const;
-        char mySymbolBorrowed(SDLKey key, const KeyControl &buttons) const;
+        char mySymbol(SDL_Keycode key) const;
+        char mySymbolBorrowed(SDL_Keycode key, const KeyControl &buttons) const;
         char myOrder(Dir::eDir dir) const;
         char driveOrder(char move);
 

--- a/src/option/MenuOptions.cpp
+++ b/src/option/MenuOptions.cpp
@@ -18,6 +18,7 @@
 #include "Slider.h"
 #include "SelectLang.h"
 #include "RadioBox.h"
+#include "MouseStroke.h"
 
 #include "Font.h"
 #include "Labels.h"
@@ -216,6 +217,7 @@ MenuOptions::createStatusBar(int width)
     void
 MenuOptions::mouseButton(const MouseStroke &stroke)
 {
+    const_cast<MouseStroke&>(stroke).disableScaling();
     m_container->mouseButton(stroke);
 }
 //-----------------------------------------------------------------


### PR DESCRIPTION
I ported the code from SDL 1.2 to SDL 2.0. There were several bugs I accidentally introduced when porting, but I fixed them.

List of bugs:
- [x] 1. no music (sound effects work though)
- [x] 2. pink corners on the world map circles. This bug appeared twice.
- [x] 3. mouse doesn't seem to work right in fullscreen
- [x] 4. When dropping a pipe on the large fish, the disintegrate effect has a green background.
- [x] 5. Options menu doesn't register mouse clicks in fullscreen. Tooltips work though.
- [x] 6. Generic icon was being shown instead of the Fish Fillets icon. This was because `setIcon` was called before window creation but it should be called after.

TODO:

- [ ] Performance: Use textures instead of surfaces when accessing the pixels of the surface isn't needed.
- [ ] Figure out why SDL_MixAudio doesn't produce any sound so the SDLMusicLooper can be re-enabled.